### PR TITLE
Fix: Remove redundant global declaration causing SyntaxError

### DIFF
--- a/stock_analyzer_gui.py
+++ b/stock_analyzer_gui.py
@@ -412,7 +412,6 @@ def create_main_window():
     root.mainloop()
 
 if __name__ == "__main__":
-    global next_scan_time_str, scanner_active # Declaration before assignment
     next_scan_time_str = "Initializing scan schedule..." # Assignment
     update_next_scan_time_label_for_worker(next_scan_time_str) # Use after assignment
 


### PR DESCRIPTION
Removes the `global next_scan_time_str, scanner_active` line from the `if __name__ == "__main__":` block in `stock_analyzer_gui.py`.

These variables are already defined in the global (module) scope at the top of the file. Redeclaring them as global within the `if __name__ == "__main__":` block after their initial assignment at the module level caused a `SyntaxError: name '...' is assigned to before global declaration`.

This change allows the assignments within the main execution block to correctly refer to the intended module-level global variables.